### PR TITLE
Missing queue name makes example not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ func main() {
 
     j := &gue.Job{
         Type:  "PrintName",
+        Queue: "name_printer",
         Args:  args,
     }
     if err := gc.Enqueue(context.Background(), j); err != nil {
@@ -107,6 +108,7 @@ func main() {
 
     j := &gue.Job{
         Type:  "PrintName",
+        Queue: "name_printer",
         RunAt: time.Now().UTC().Add(30 * time.Second), // delay 30 seconds
         Args:  args,
     }


### PR DESCRIPTION
The example code in README.md doesn't work as the correct queue on the jobs are not set.